### PR TITLE
Bug fixes: incorrect reference causes the compiler to stop running: vendor/cm/config/cm_audio.mk

### DIFF
--- a/build/tools/extract_utils.sh
+++ b/build/tools/extract_utils.sh
@@ -638,8 +638,8 @@ function oat2dex() {
     local OAT=
 
     if [ -z "$BAKSMALIJAR" ] || [ -z "$SMALIJAR" ]; then
-        export BAKSMALIJAR="$CM_ROOT"/vendor/cm/build/tools/smali/baksmali.jar
-        export SMALIJAR="$CM_ROOT"/vendor/cm/build/tools/smali/smali.jar
+        export BAKSMALIJAR="$CM_ROOT"/vendor/tesla/build/tools/smali/baksmali.jar
+        export SMALIJAR="$CM_ROOT"/vendor/tesla/build/tools/smali/smali.jar
     fi
 
     # Extract existing boot.oats to the temp folder

--- a/config/common.mk
+++ b/config/common.mk
@@ -117,7 +117,7 @@ PRODUCT_COPY_FILES +=  \
     vendor/tesla/proprietary/TeslaClockWidget.apk:system/app/TeslaClockWidget/TeslaClockWidget.apk \
 
 # Include CM audio files
-include vendor/cm/config/cm_audio.mk
+include vendor/tesla/config/cm_audio.mk
 
 # Theme engine
 include vendor/tesla/config/themes_common.mk


### PR DESCRIPTION
Bug fixes: incorrect reference causes the compiler to stop running: vendor/cm/config/cm_audio.mk
Signed-off-by: Flowertome <gesangtome@foxmail.com>